### PR TITLE
CI: Add GitHub Action for create_perf_json.py

### DIFF
--- a/.github/workflows/create-perf-json.yml
+++ b/.github/workflows/create-perf-json.yml
@@ -1,0 +1,40 @@
+# This workflow will setup Python, run create_perf_json.py, and archive
+# perf JSON files.
+
+name: Create perf json
+
+on:
+  push:
+  pull_request:
+  schedule:
+    # Tuesdays at 9AM PST
+    - cron: '0 16 * * 2'
+
+permissions:
+  contents: read
+
+jobs:
+  create-perf-json:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout perfmon
+      uses: actions/checkout@v3
+
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
+
+    - name: Create perf json files
+      working-directory: ./scripts
+      run: python create_perf_json.py -v
+
+    - name: Archive perf json files
+      uses: actions/upload-artifact@v3
+      with:
+        name: perf-json
+        path: scripts/perf
+        retention-days: 10
+        if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+scripts/perf


### PR DESCRIPTION
The goal of this PR is to introduce a simple GitHub action to run and check `create_perf_json.py`. With potentially ongoing JSON refactoring I want to make sure this script continues to function. As a somewhat related change, `scripts/perf` is added to `.gitignore` since it is an output directory.

#### Action triggered by
1. Pushes.
2. Pull requests.
3. Fixed schedule for once a week.

#### Archives
The default output directory `scripts/perf` for 10 days.