### PR TITLE
Fixes for create_perf_json.py

### DIFF
--- a/scripts/create_perf_json.py
+++ b/scripts/create_perf_json.py
@@ -853,7 +853,7 @@ class Model:
 
 
                 def bracket(expr):
-                    if '/' in expr or '*' in expr or '+' in expr or '-' in expr:
+                    if any([x in expr for x in ['/', '*', '+', '-', 'if']]):
                         if expr.startswith('(') and expr.endswith(')'):
                             return expr
                         else:

--- a/scripts/create_perf_json.py
+++ b/scripts/create_perf_json.py
@@ -840,10 +840,6 @@ class Model:
                     changed = True
                     while changed:
                         changed = False
-                        m = re.fullmatch(r'(.*) if ([01]) else (.*)', form)
-                        if m:
-                            changed = True
-                            form = m.group(1) if m.group(2) == '1' else m.group(3)
                         m = re.search(r'\(([0-9.]+) \* ([A-Za-z_]+)\) - \(([0-9.]+) \* ([A-Za-z_]+)\)', form)
                         if m and m.group(2) == m.group(4):
                             changed = True

--- a/scripts/create_perf_json.py
+++ b/scripts/create_perf_json.py
@@ -972,10 +972,13 @@ class Model:
                 if locate:
                     desc = desc + ' Sample with: ' + locate
 
-                j = {
-                    'MetricName': name,
-                    'MetricExpr': metric.ParsePerfJson(form).Simplify().ToPerfJson(),
-                }
+                try:
+                    j = {
+                        'MetricName': name,
+                        'MetricExpr': metric.ParsePerfJson(form).Simplify().ToPerfJson(),
+                    }
+                except SyntaxError as e:
+                    raise SyntaxError(f'Parsing metric {name} for {self.longname}') from e
 
                 if group and len(group) > 0:
                     j['MetricGroup'] = group

--- a/scripts/metric.py
+++ b/scripts/metric.py
@@ -562,7 +562,7 @@ def RewriteMetricsInTermsOfOthers(metrics: list[Tuple[str, Expression]]
     updated = outer_expression
     while True:
       for inner_name, inner_expression in metrics:
-        if inner_name == outer_name:
+        if inner_name.lower() == outer_name.lower():
           continue
         if inner_name in updates:
           inner_expression = updates[inner_name]


### PR DESCRIPTION
A collection of create_perf_json fixes.

Perf metrics are case insensitive but we may have multiple metrics during parsing with different capitalizations. If this happens we may end up making the metric recursive with itself. Avoid this by making the rewrite test case insensitive.

Avoid string based substitution of "if" expressions, use the metric approach that doesn't break parentheses.

Add extra debug logging if parsing a metric yields a syntax error.