### PR TITLE
mapfile: Add EMR

### DIFF
--- a/mapfile.csv
+++ b/mapfile.csv
@@ -118,6 +118,7 @@ GenuineIntel-6-8D,V1.10,/TGL/events/tigerlake_uncore_experimental.json,uncore ex
 GenuineIntel-6-8F,V1.10,/SPR/events/sapphirerapids_core.json,core,,,
 GenuineIntel-6-8F,V1.10,/SPR/events/sapphirerapids_uncore.json,uncore,,,
 GenuineIntel-6-8F,V1.10,/SPR/events/sapphirerapids_uncore_experimental.json,uncore experimental,,,
+GenuineIntel-6-CF,V1.10,/SPR/events/sapphirerapids_core.json,core,,,
 GenuineIntel-6-6A,V1.18,/ICX/events/icelakex_core.json,core,,,
 GenuineIntel-6-6A,V1.18,/ICX/events/icelakex_uncore.json,uncore,,,
 GenuineIntel-6-6A,V1.18,/ICX/events/icelakex_uncore_experimental.json,uncore experimental,,,


### PR DESCRIPTION
Add `0xCF` to support Linux enabling. Emerald Rapids device ID referenced from [1].

[1] https://lore.kernel.org/all/20221103203310.5058-1-tony.luck@intel.com/