### PR TITLE
Improvements to create_perf_json.py

### DIFF
--- a/scripts/create_perf_json.py
+++ b/scripts/create_perf_json.py
@@ -800,6 +800,7 @@ class Model:
                         ] + td_event_fixups,
                         'TGL': [
                             ('UNC_ARB_COH_TRK_REQUESTS.ALL', 'arb@event\=0x84\,umask\=0x1@'),
+                            ('UNC_ARB_DAT_OCCUPANCY.RD:c1', 'UNC_ARB_DAT_OCCUPANCY.RD@cmask\=1@'),
                             ('UNC_ARB_TRK_REQUESTS.ALL', 'arb@event\=0x81\,umask\=0x1@'),
                         ] + td_event_fixups,
                     }

--- a/scripts/create_perf_json.py
+++ b/scripts/create_perf_json.py
@@ -12,6 +12,7 @@
 # EXAMPLE: python create_perf_json.py
 import argparse
 import collections
+from dataclasses import dataclass
 import csv
 from itertools import takewhile
 import json
@@ -541,18 +542,16 @@ class Model:
             _verboseprint(f'Missing TMA CPU for {self.shortname}')
             return []
 
+        @dataclass
         class PerfMetric:
-           def  __init__(self, name: str, form: Optional[str], desc: str, groups: str,
-                         locate: str, scale_unit: Optional[str],
-                         parent_metric: Optional[str], threshold: Optional[str]):
-               self.name = name
-               self.form = form
-               self.desc = desc
-               self.groups = groups
-               self.locate = locate
-               self.scale_unit = scale_unit
-               self.parent_metric = parent_metric
-               self.threshold = threshold
+           name: str
+           form: Optional[str]
+           desc: str
+           groups: str
+           locate: str
+           scale_unit: Optional[str]
+           parent_metric: Optional[str]
+           threshold: Optional[str]
 
         # All the metrics read from the CSV file.
         info : list[PerfMetric] = []

--- a/scripts/create_perf_json.py
+++ b/scripts/create_perf_json.py
@@ -977,6 +977,13 @@ class Model:
                         _verboseprint2(f'duplicate metric {name} forms differ'
                                        f'\n\tnew: {form}'
                                        f'\n\texisting: {m["MetricExpr"]}')
+                    if not locate and ' Sample with: ' not in desc:
+                        if 'PublicDescription' in m:
+                            d = m['PublicDescription']
+                        else:
+                            d = m['BriefDescription']
+                        if ' Sample with: ' in d:
+                            locate = re.sub(r'.* Sample with: (.*)', r'\1', d)
                     jo.remove(m)
 
                 if locate:

--- a/scripts/create_perf_json.py
+++ b/scripts/create_perf_json.py
@@ -1000,9 +1000,137 @@ class Model:
                 else:
                     j['BriefDescription'] = desc
 
-                if j['MetricName'] == 'tma_info_page_walks_utilization' or j[
-                        'MetricName'] == 'tma_backend_bound':
-                    j['MetricConstraint'] = 'NO_NMI_WATCHDOG'
+                # Don't group events as there can never be sufficient counters.
+                no_group = 'NO_GROUP_EVENTS'
+                # Inform perf not to group metrics if the NMI watchdog
+                # is enabled.
+                nmi = 'NO_GROUP_EVENTS_NMI'
+                # Inform perf not to group events if SMT is enabled. This is for
+                # the erratas SNB: BJ122, IVB: BV98, HSW: HSD29, as well as when
+                # EBS_Mode causes additional events to be required.
+                smt = 'NO_GROUP_EVENTS_SMT'
+
+                sandybridge_constraints = {
+                    # Metrics with more events than counters.
+                    'tma_branch_mispredicts': no_group,
+                    'tma_contested_accesses': no_group,
+                    'tma_core_bound': no_group,
+                    'tma_data_sharing': no_group,
+                    'tma_fb_full': no_group,
+                    'tma_l3_hit_latency': no_group,
+                    'tma_local_dram': no_group,
+                    'tma_lock_latency': no_group,
+                    'tma_machine_clears': no_group,
+                    'tma_memory_bound': no_group,
+                    'tma_ports_utilization': no_group,
+                    'tma_remote_cache': no_group,
+                    'tma_remote_dram': no_group,
+                    'tma_split_loads': no_group,
+                    'tma_store_latency': no_group,
+                    'tma_info_load_miss_real_latency': no_group,
+                    'tma_info_mlp': no_group,
+                    # Metrics that would fit were the NMI watchdog disabled.
+                    'tma_alu_op_utilization': nmi,
+                    'tma_backend_bound': nmi,
+                    'tma_cisc': nmi,
+                    'tma_load_op_utilization': nmi,
+                    # SMT errata workarounds.
+                    'tma_dram_bound': smt,
+                    'tma_l3_bound': smt,
+                }
+                skylake_constraints = {
+                    # Metrics with more events than counters.
+                    'tma_branch_mispredicts': no_group,
+                    'tma_contested_accesses': no_group,
+                    'tma_core_bound': no_group,
+                    'tma_dram_bound': no_group,
+                    'tma_data_sharing': no_group,
+                    'tma_false_sharing': no_group,
+                    'tma_fp_arith': no_group,
+                    'tma_info_fp_arith_utilization': no_group,
+                    'tma_fp_vector': no_group,
+                    'tma_l2_bound': no_group,
+                    'tma_machine_clears': no_group,
+                    'tma_memory_bound': no_group,
+                    'tma_pmm_bound': no_group,
+                    'tma_info_big_code': no_group,
+                    'tma_info_core_bound_likely': no_group,
+                    'tma_info_dsb_misses': no_group,
+                    'tma_info_flopc': no_group,
+                    'tma_info_gflops': no_group,
+                    'tma_info_instruction_fetch_bw': no_group,
+                    'tma_info_iparith': no_group,
+                    'tma_info_ipflop': no_group,
+                    'tma_info_memory_bandwidth': no_group,
+                    'tma_info_memory_data_tlbs': no_group,
+                    'tma_info_memory_latency': no_group,
+                    'tma_info_mispredictions': no_group,
+                    'tma_info_jump': no_group,
+                    # Metrics that would fit were the NMI watchdog disabled.
+                    'tma_dtlb_load': nmi,
+                    'tma_load_stlb_hit': nmi,
+                    'tma_fb_full': nmi,
+                    'tma_remote_cache': nmi,
+                    'tma_split_loads': nmi,
+                    'tma_store_latency': nmi,
+                    'tma_info_page_walks_utilization': nmi,
+                }
+                icelake_constraints = {
+                    'tma_contested_accesses': no_group,
+                    'tma_data_sharing': no_group,
+                    'tma_dram_bound': no_group,
+                    'tma_l2_bound': no_group,
+                    'tma_lock_latency': no_group,
+                    'tma_info_big_code': no_group,
+                    'tma_info_flopc': no_group,
+                    'tma_info_fp_arith_utilization': no_group,
+                    # TODO: Don't not group as weak groups will
+                    # preserve top-down event groups.
+                    #'tma_info_dsb_misses': no_group,
+                    #'tma_fp_arith': no_group,
+                    #'tma_memory_operations': no_group,
+                    #'tma_other_light_ops': no_group,
+                    #'tma_info_branch_misprediction_cost': no_group,
+                    #'tma_info_core_bound_likely': no_group,
+                    #'tma_info_instruction_fetch_bw': no_group,
+                    #'tma_info_memory_data_tlbs': no_group,
+                    #'tma_info_memory_latency': no_group,
+                    #'tma_info_mispredictions': no_group,
+                    #'tma_info_retire': no_group,
+                }
+                errata_constraints = {
+                    # 4 programmable, 3 fixed counters per HT
+                    'JKT': sandybridge_constraints,
+                    'SNB': sandybridge_constraints,
+                    'IVB': sandybridge_constraints,
+                    'IVT': sandybridge_constraints,
+                    'HSW': sandybridge_constraints,
+                    'HSX': sandybridge_constraints,
+                    'BDW': sandybridge_constraints,
+                    'BDX': sandybridge_constraints,
+                    'BDW-DE': sandybridge_constraints,
+                    # 4 programmable, 3 fixed counters per HT
+                    'SKL': skylake_constraints,
+                    'KBL': skylake_constraints,
+                    'SKX': skylake_constraints,
+                    'KBLR': skylake_constraints,
+                    'CFL': skylake_constraints,
+                    'CML': skylake_constraints,
+                    'CLX': skylake_constraints,
+                    'CPX': skylake_constraints,
+                    'CNL': skylake_constraints,
+                    # 8 programmable, 5 fixed counters per HT
+                    'ICL': icelake_constraints,
+                    'ICX': icelake_constraints,
+                    'RKL': icelake_constraints,
+                    'TGL': icelake_constraints,
+                    'ADL': icelake_constraints,
+                    'ADLN': icelake_constraints,
+                    'RPL': icelake_constraints,
+                    'SPR': icelake_constraints,
+                }
+                if name in errata_constraints[self.shortname]:
+                    j['MetricConstraint'] = errata_constraints[self.shortname][name]
 
                 if pmu_prefix != 'cpu':
                     j['Unit'] = pmu_prefix

--- a/scripts/create_perf_json.py
+++ b/scripts/create_perf_json.py
@@ -1431,6 +1431,10 @@ class Model:
 
         if len(metrics) > 0:
             metrics.extend(self.cstate_json())
+            metrics = sorted(metrics,
+                             key=lambda m: (m['Unit'] if 'Unit' in m else 'cpu',
+                                            m['MetricName'])
+                             )
             metrics = rewrite_metrics_in_terms_of_others(metrics)
             with open(f'{outdir}/{self.shortname.lower().replace("-","")}-metrics.json',
                       'w', encoding='ascii') as perf_metric_json:

--- a/scripts/metric.py
+++ b/scripts/metric.py
@@ -44,6 +44,9 @@ class Expression:
   def __and__(self, other: Union[int, float, 'Expression']) -> 'Operator':
     return Operator('&', self, other)
 
+  def __rand__(self, other: Union[int, float, 'Expression']) -> 'Operator':
+    return Operator('&', other, self)
+
   def __lt__(self, other: Union[int, float, 'Expression']) -> 'Operator':
     return Operator('<', self, other)
 
@@ -88,7 +91,10 @@ def _Constify(val: Union[bool, int, float, Expression]) -> Expression:
 
 
 # Simple lookup for operator precedence, used to avoid unnecessary
-# brackets. Precedence matches that of python and the simple expression parser.
+# brackets. Precedence matches that of the simple expression parser
+# but differs from python where comparisons are lower precedence than
+# the bitwise &, ^, | but not the logical versions that the expression
+# parser doesn't have.
 _PRECEDENCE = {
     '|': 0,
     '^': 1,

--- a/scripts/metric.py
+++ b/scripts/metric.py
@@ -420,7 +420,8 @@ class Metric:
                description: str,
                expr: Expression,
                scale_unit: str,
-               constraint: bool = False):
+               constraint: bool = False,
+               threshold: Optional[Expression] = None):
     self.name = name
     self.description = description
     self.expr = expr.Simplify()
@@ -431,6 +432,7 @@ class Metric:
     else:
       self.scale_unit = f'1{scale_unit}'
     self.constraint = constraint
+    self.threshold = threshold
     self.groups = set()
 
   def __lt__(self, other):
@@ -456,6 +458,8 @@ class Metric:
     }
     if self.constraint:
       result['MetricConstraint'] = 'NO_NMI_WATCHDOG'
+    if self.threshold:
+      result['MetricThreshold'] = self.threshold.ToPerfJson()
 
     return result
 


### PR DESCRIPTION
A collection of updates:
- rename TMA's Info metrics to match the Valkyrie Into metric names (ie tma_info_...).
- add support for Locate-with to Valkyrie metrics.
- add event grouping flags, so that events for metrics aren't grouped if the group won't count in that scenario. The flag names need an updated Linux perf. The groupings were computed manually based on SNB, SKL or ICL style groupings.
- generate the 'Threshold' column as a boolean metric that combines parent and other values as specified. This value is also copied to Valkyrie metrics.

Adding the threshold is a precursor to removing hard coded metrics out of the Linux perf code. The hard coded metrics use duplicate aggregation logic which was the cause of a double counting regression. Everything else is either Valkyrie alignment or minor improvements.