### PR TITLE
readme: Update additional information and errata links

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,9 +284,10 @@ Please use SNR core event files. The EHL events folder is populated with a copy 
 Please use KNL perfmon event files for KNM. The KNM events folder is populated with copies of KNL for convenience.
 
 ## For additional information
-* Intel Platform Monitoring Homepage http://software.intel.com/en-us/platform-monitoring/
-* http://software.intel.com/en-us/articles/performance-monitoring-on-intel-xeon-processor-e5-family
-* http://software.intel.com/en-us/articles/monitoring-integrated-memory-controller-requests-in-the-2nd-3rd-and-4th-generation-intel
+* Event documention https://perfmon-events.intel.com/
+* Intel&copy; Platform Analysis Technology https://www.intel.com/content/www/us/en/developer/topic-technology/platform-analysis-technology/overview.html
+* https://www.intel.com/content/dam/www/public/us/en/documents/specification-updates/xeon-e5-family-spec-update.pdf
+* Monitoring Integrated Memory Controller Requests in the 2nd, 3rd, 4th, 5th, 6th generation Intel&copy; Core&trade; processors https://www.intel.com/content/www/us/en/developer/articles/technical/monitoring-integrated-memory-controller-requests-in-the-2nd-3rd-and-4th-generation-intel.html
 * http://www.intel.com/content/dam/www/public/us/en/documents/specification-updates/4th-gen-core-family-desktop-specification-update.pdf
 
 # How to Contribute

--- a/README.md
+++ b/README.md
@@ -267,9 +267,9 @@ when the store hits in the L1 cache and 0 when it misses.
 ### Errata
 This field lists the known bugs that apply to the events. For the latest, up to date errata refer to
 
-* Haswell http://www.intel.com/content/dam/www/public/us/en/documents/specification-updates/4th-gen-core-family-mobile-specification-update.pdf
-* IvyBridge https://www-ssl.intel.com/content/dam/www/public/us/en/documents/specification-updates/3rd-gen-core-desktop-specification-update.pdf
-* SandyBridge https://www-ssl.intel.com/content/dam/www/public/us/en/documents/specification-updates/2nd-gen-core-family-mobile-specification-update.pdf
+* Jaketown https://www.intel.com/content/dam/www/public/us/en/documents/specification-updates/xeon-e5-family-spec-update.pdf
+* Haswell http://www.intel.com/content/dam/www/public/us/en/documents/specification-updates/4th-gen-core-family-desktop-specification-update.pdf
+* Ivy Bridge https://www-ssl.intel.com/content/dam/www/public/us/en/documents/specification-updates/3rd-gen-core-desktop-specification-update.pdf
 
 ### Offcore
 This field is specific to the json format. There is only 1 file for core and offcore events in this format. This field is set to 1 for offcore events
@@ -286,9 +286,7 @@ Please use KNL perfmon event files for KNM. The KNM events folder is populated w
 ## For additional information
 * Event documention https://perfmon-events.intel.com/
 * Intel&copy; Platform Analysis Technology https://www.intel.com/content/www/us/en/developer/topic-technology/platform-analysis-technology/overview.html
-* https://www.intel.com/content/dam/www/public/us/en/documents/specification-updates/xeon-e5-family-spec-update.pdf
 * Monitoring Integrated Memory Controller Requests in the 2nd, 3rd, 4th, 5th, 6th generation Intel&copy; Core&trade; processors https://www.intel.com/content/www/us/en/developer/articles/technical/monitoring-integrated-memory-controller-requests-in-the-2nd-3rd-and-4th-generation-intel.html
-* http://www.intel.com/content/dam/www/public/us/en/documents/specification-updates/4th-gen-core-family-desktop-specification-update.pdf
 
 # How to Contribute
 ## Metrics


### PR DESCRIPTION
* Insert a new link for event documentation in HTML form https://perfmon-events.intel.com.
* Update the Platform Monitoring link since it was not valid. The Internet Archive's last relevant snapshot was in 2014 https://web.archive.org/web/20130709032053/http://software.intel.com/en-us/platform-monitoring. Later crawls were redirected to https://www.intel.com/content/www/us/en/developer/topic-technology/platform-analysis-technology/overview.html.
* Update link for monitoring integrated memory controller requests. The Internet Archive's last snapshot for the prior URL was in 2018 https://web.archive.org/web/20181106212644/http://software.intel.com/en-us/articles/monitoring-integrated-memory-controller-requests-in-the-2nd-3rd-and-4th-generation-intel.
* Replace performance-monitoring-on-intel-xeon-processor-e5-family link with the Xeon E5 family spec update. The original URL pointed to an article titled, "Memory and Cache Profiling Erratum on Intel Xeon processor E5 family" https://web.archive.org/web/20190203094700/http://software.intel.com/en-us/articles/performance-monitoring-on-intel-xeon-processor-e5-family.
* Moved specification update links from additional information to errata.
* Removed SNB from errata. The spec update PDF is not published. 
* Replaced HSW mobile with desktop spec update in errata. The mobile spec update PDF is not published.
