### PR TITLE
Introduce CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+# Default owner. Later matches take precedence. Refer to the below link for additional details.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+* @edwarddavidbaker
+
+# TMA and Atom TMA.
+TMA_Metrics* @ayasini
+Atom_TMA* @claudiaromo @rpmclaug
+E-core_TMA* @claudiaromo @rpmclaug
+
+# Platform metrics.
+**/metrics @1perrytaylor @calebbiggers @kshiprab
+
+# Platform events.
+**/events @edwarddavidbaker @kshiprab
+
+# Perf JSON scripting. Notify reviewers at the directory level for now.
+# When additional scripting is added we can be more specific.
+scripts/ @captain5050 @1perrytaylor @calebbiggers

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+__pycache__/
 .idea
 scripts/perf
 scripts/inputs


### PR DESCRIPTION
This commit introduces GitHub's CODEOWNERS file to automatically add reviewers to pull requests. Listed owners are a starting point for reviews, or to add other contacts to the pull request.

Gitignore is also updated to add Python's `__pycache__`.