### PR TITLE
Fix format used for Skylake UNC_ARB_TRK_OCCUPANCY.DATA_READ:c1

### DIFF
--- a/scripts/create_perf_json.py
+++ b/scripts/create_perf_json.py
@@ -976,7 +976,7 @@ class Model:
                         'RKL': td_event_fixups,
                         'SKL': [
                             ('UNC_ARB_TRK_OCCUPANCY.DATA_READ:c1',
-                             'UNC_ARB_TRK_OCCUPANCY.DATA_READ@thresh\=1@'),
+                             'UNC_ARB_TRK_OCCUPANCY.DATA_READ@cmask\=1@'),
                         ],
                         'SKX': [
                             ('UNC_M_CLOCKTICKS:one_unit', 'imc_0@event\=0x0@'),


### PR DESCRIPTION
uncore_arb on Skylake has no thresh format, it should use cmask. This confusion creeps in because on SkylakeX uncore_cha is used instead of uncore_arb, uncore_cha having a thresh format.