### PR TITLE
CI Updates: Add dependabot.yml and limit link checks to intel/perfmon

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# Dependabot version updates for packages used by perfmon tooling.
+
+version: 2
+updates:
+  # Enable version updates for Python packages.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1
+
+  # Enable version updates from GitHub Actions.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1

--- a/.github/workflows/check-markdown-links.yml
+++ b/.github/workflows/check-markdown-links.yml
@@ -1,12 +1,6 @@
 name: Check Markdown links
 
 on:
-  pull_request:
-    branches:
-      - main
-  push:
-    branches:
-      - main
   schedule:
     # Tuesdays at 9AM PST. GitHub Actions run in UTC.
     - cron: '0 16 * * 2'
@@ -14,6 +8,9 @@ on:
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
+    # Only run link checks in the main repo and not forks. The intent
+    # is a low volume reminder to update stale links.
+    if: github.repository == 'intel/perfmon'
     steps:
     - uses: actions/checkout@v3
     - uses: gaurav-nelson/github-action-markdown-link-check@v1


### PR DESCRIPTION
* Dependabot
  * Introduce `dependabot.yml` to enable version updates for pip and GitHub Actions. Dependabot scanning and alerts for dependencies with security updates is already enabled. 
  * At the moment Python scripts aren't using additional packages via `requirements.txt`. Enabling PIP scans is for upcoming tools / checks.
* Limit link checks to `intel/perfmon`
     * Automatically checking links is intended to be a low volume reminder to update stale links. It isn't necessary for every fork (examples below) to also act as a reminder. This pull request checks if the repository is `intel/perfmon` and further removes `push` and `pull_request`  triggers.
     * https://github.com/edwarddavidbaker/perfmon/actions/workflows/check-markdown-links.yml?query=event%3Aschedule
     * https://github.com/captain5050/perfmon/actions/workflows/check-markdown-links.yml?query=event%3Aschedule