### PR TITLE
Rework broadwell-de conversion

### DIFF
--- a/scripts/create_perf_json.py
+++ b/scripts/create_perf_json.py
@@ -739,10 +739,24 @@ class Model:
                 """Find the formula for CPU in the current CSV line."""
                 cell = field(tma_cpu)
                 if not cell:
-                    for j in ratio_column[tma_cpu]:
+                    cpu = tma_cpu
+                    # BDW-DE is a BDW with the server
+                    # uncore. Page_Walks_Utilization must come from
+                    # the server BDX CPU.
+                    if self.shortname == 'BDW-DE' and field('Level1') == 'Page_Walks_Utilization':
+                        cpu = 'BDX'
+                    for j in ratio_column[cpu]:
                         cell = field(j)
                         if cell:
                             break
+                    # UNC_ARB is a BDW uncore PMU not present on
+                    # BDW-DE, substitute for the BDX version.
+                    if self.shortname == 'BDW-DE' and 'UNC_ARB' in cell:
+                        for j in ratio_column['BDX']:
+                            cell = field(j)
+                            if cell:
+                                break
+
                 if 'UNC_CLOCK.SOCKET' in cell and self.shortname in ['BDW-DE', 'TGL']:
                     cell = None
                 return cell
@@ -929,10 +943,6 @@ class Model:
                             ('UNC_C_TOR_INSERTS.MISS_OPCODE:opc=0x182',
                              'UNC_C_TOR_INSERTS.MISS_OPCODE@filter_opc\=0x182@'),
                             ('UNC_C_CLOCKTICKS:one_unit', 'cbox_0@event\=0x0@'),
-                        ],
-                        'BDW-DE': [
-                            ('UNC_ARB_COH_TRK_REQUESTS.ALL', 'arb@event\=0x84\,umask\=0x1@'),
-                            ('UNC_ARB_TRK_REQUESTS.ALL', 'arb@event\=0x81\,umask\=0x1@'),
                         ],
                         'CLX': [
                             ('UNC_M_CLOCKTICKS:one_unit', 'imc_0@event\=0x0@'),
@@ -1154,17 +1164,7 @@ class Model:
             def save_form(name, group, form, desc, locate, scale_unit, threshold,
                           issues):
                 if self.shortname == 'BDW-DE':
-                    if name == 'Page_Walks_Utilization':
-                        # Force in the BDX versions.
-                        form = ('(ITLB_MISSES.WALK_DURATION + '
-                                'DTLB_LOAD_MISSES.WALK_DURATION + '
-                                'DTLB_STORE_MISSES.WALK_DURATION + 7 * '
-                                '(DTLB_STORE_MISSES.WALK_COMPLETED + '
-                                'DTLB_LOAD_MISSES.WALK_COMPLETED + '
-                                'ITLB_MISSES.WALK_COMPLETED)) / (2 * CORE_CLKS)')
-                    elif name in ['tma_false_sharing',
-                                  'tma_info_system_mem_parallel_requests',
-                                  'tma_info_system_mem_request_latency']:
+                    if name in ['tma_false_sharing']:
                         # Uncore events missing for BDW-DE, so drop.
                         _verboseprint3(f'Dropping metric {name}')
                         return


### PR DESCRIPTION
Broadwell-de follows broadwell for core events but broadwellx for uncore. Prior to this patch the uncore_arb PMU was tried to be used, however, it isn't present and uncore_cbox should be used. Rework how this is done in the code, in find_form for Page_Walks_Utilization force the BDX lookup. For lookups that result in UNC_ARB retry the lookup using BDX as lookup order.

Note, this only changes the metric tma_info_system_dram_bw_use as:
-        "MetricExpr": "64 * (arb@event\\=0x81\\,umask\\=0x1@ + arb@event\\=0x84\\,umask\\=0x1@) / 1e6 / duration_time / 1e3",
+        "MetricExpr": "64 * (UNC_M_CAS_COUNT.RD + UNC_M_CAS_COUNT.WR) / 1e9 / duration_time",
