### PR TITLE
WIP: create_perf_json: Support 'FIXED' event codes

### DIFF
--- a/SKL/events/skylake_core.json
+++ b/SKL/events/skylake_core.json
@@ -8,7 +8,7 @@
   },
   "Events": [
     {
-      "EventCode": "0x00",
+      "EventCode": "FIXED",
       "UMask": "0x01",
       "EventName": "INST_RETIRED.ANY",
       "BriefDescription": "Instructions retired from execution.",
@@ -31,7 +31,7 @@
       "Deprecated": "0"
     },
     {
-      "EventCode": "0x00",
+      "EventCode": "FIXED",
       "UMask": "0x02",
       "EventName": "CPU_CLK_UNHALTED.THREAD",
       "BriefDescription": "Core cycles when the thread is not in halt state",
@@ -54,7 +54,7 @@
       "Deprecated": "0"
     },
     {
-      "EventCode": "0x00",
+      "EventCode": "FIXED",
       "UMask": "0x02",
       "EventName": "CPU_CLK_UNHALTED.THREAD_ANY",
       "BriefDescription": "Core cycles when at least one thread on the physical core is not in halt state.",
@@ -77,7 +77,7 @@
       "Deprecated": "0"
     },
     {
-      "EventCode": "0x00",
+      "EventCode": "FIXED",
       "UMask": "0x03",
       "EventName": "CPU_CLK_UNHALTED.REF_TSC",
       "BriefDescription": "Reference cycles when the core is not in halt state.",

--- a/scripts/create_perf_json.py
+++ b/scripts/create_perf_json.py
@@ -353,6 +353,14 @@ class PerfmonJsonEvent:
             self.event_code = "0xff"
             self.umask = None
 
+        # Unset event_code for fixed core counters. Example:
+        #   "EventCode": "FIXED",
+        #   "EventName": "INST_RETIRED.ANY",
+        #   "Counter": "Fixed counter 0",
+        if "Counter" in jd and "fixed counter" in jd["Counter"].lower():
+            if str(self.event_code).lower() == 'fixed':
+                self.event_code = None
+
         if self.filter:
             remove_filter_start = [
                 "cbofilter",


### PR DESCRIPTION
This pull request unsets `EventCode` for `FIXED` events. Previously for fixed events the `EventCode` was `0x00`. The `get()` helper used to process JSON attributes drops `0x00` (returns None). Here we add an extra check to also set `event_code` to None if `EventCode` is `FIXED`.
    
 Example FIXED event:
```
        {
          "EventCode": "FIXED",
          "UMask": "0x01",
          "EventName": "INST_RETIRED.ANY",
          "Counter": "Fixed counter 0",
          "CounterHTOff": "Fixed counter 0",
          <snip>
          "Offcore": "0",
          "Deprecated": "0"
        }
```