### PR TITLE
create_perf_json: Migrate to pathlib.Path for file operations

### DIFF
--- a/.github/workflows/create-perf-json.yml
+++ b/.github/workflows/create-perf-json.yml
@@ -27,6 +27,10 @@ jobs:
       with:
         python-version: "3.x"
 
+    - name: Run unittests
+      working-directory: ./scripts/unittesting
+      run: python metric_test.py
+
     - name: Create perf json files
       working-directory: ./scripts
       run: python create_perf_json.py -v


### PR DESCRIPTION
Previously event files were hosted at https://download.01.org/perfmon and fetching them with `urllib` was necessary. After migrating to GitHub we no longer need to fetch files using `urllib`.
    
* Script arguments
    * Removed base path argument. At this point in time, `create_perf_json.py` only operates on files in this repository.
    * Add Path type to argument parser.
* Migrate to Path
    * Use `pathlib.Path` to construct file and folder paths.
    * Updated type annotations with Path.
    * Replaced `urlopen()` with `open()`.
    * Removed unused imports `os` and `urllib`.
    * Switched a few `try:` blocks to `if <path>.is_file()`.
* CI
    * Execute `metric` tests.   