### PR TITLE
ADL/RPL/SPR metric fixes

### DIFF
--- a/scripts/create_perf_json.py
+++ b/scripts/create_perf_json.py
@@ -1073,15 +1073,14 @@ class Model:
                     if pmu_prefix != 'cpu':
                         for name in events:
                             if events[name].unit.startswith('cpu') and name in form:
-                                if form == name:
-                                    form = f'{pmu_prefix}@{name}@'
-                                else:
-                                    form = re.sub(rf'([^@]){name}:([a-zA-Z])',
-                                                  rf'\1{pmu_prefix}@{name}@\2',
-                                                  form, re.IGNORECASE)
-                                    form = re.sub(rf'([^@]){name}([^a-zA-Z0-9_])',
-                                                  rf'\1{pmu_prefix}@{name}@\2',
-                                                  form, re.IGNORECASE)
+                                if form == name or form.startswith(f'{name} '):
+                                    form = f'{pmu_prefix}@{name}@' + form[len(name):]
+                                form = re.sub(rf'([^@]){name}:([a-zA-Z])',
+                                              rf'\1{pmu_prefix}@{name}@\2',
+                                              form, re.IGNORECASE)
+                                form = re.sub(rf'([^@]){name}([^a-zA-Z0-9_])',
+                                              rf'\1{pmu_prefix}@{name}@\2',
+                                              form, re.IGNORECASE)
 
                     changed = True
                     while changed:

--- a/scripts/create_perf_json.py
+++ b/scripts/create_perf_json.py
@@ -1365,6 +1365,18 @@ class Model:
                     'tma_split_stores': nmi,
                     'tma_store_fwd_blk': nmi,
                 }
+                # Alderlake/sapphirerapids add topdown l2 events
+                # meaning fewer events and triggering NMI issues.
+                alderlake_constraints = {
+                    # Metrics with more events than counters.
+                    'tma_info_system_mem_read_latency': no_group,
+                    'tma_info_system_mem_request_latency': no_group,
+                    # Metrics that would fit were the NMI watchdog disabled.
+                    'tma_ports_utilized_2': nmi,
+                    'tma_ports_utilized_3m': nmi,
+                    'tma_memory_fence': nmi,
+                    'tma_slow_pause': nmi,
+                }
                 errata_constraints = {
                     # 4 programmable, 3 fixed counters per HT
                     'JKT': sandybridge_constraints,
@@ -1391,10 +1403,11 @@ class Model:
                     'ICX': icelake_constraints,
                     'RKL': icelake_constraints,
                     'TGL': icelake_constraints,
-                    'ADL': icelake_constraints,
-                    'ADLN': icelake_constraints,
-                    'RPL': icelake_constraints,
-                    'SPR': icelake_constraints,
+                    # As above but l2 topdown counters
+                    'ADL': alderlake_constraints,
+                    'ADLN': alderlake_constraints,
+                    'RPL': alderlake_constraints,
+                    'SPR': alderlake_constraints,
                 }
                 if name in errata_constraints[self.shortname]:
                     j['MetricConstraint'] = errata_constraints[self.shortname][name]


### PR DESCRIPTION
Ensure events on hybrid are all prefixed with the PMU (cpu_core/cpu_atom) including those at the beginning of a formula.
Add new constraints for ADL/RPL/SPR due to topdown l2 events changing counter requirements.