### PR TITLE
ci: Pin GitHub Actions

### DIFF
--- a/.github/workflows/check-markdown-links.yml
+++ b/.github/workflows/check-markdown-links.yml
@@ -15,8 +15,8 @@ jobs:
     # is a low volume reminder to update stale links.
     if: github.repository == 'intel/perfmon'
     steps:
-    - uses: actions/checkout@v4
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - uses: gaurav-nelson/github-action-markdown-link-check@d53a906aa6b22b8979d33bc86170567e619495ec # 1.0.15
       with:
         use-verbose-mode: 'yes'
         config-file: '.github/workflows/mlc_config.json'

--- a/.github/workflows/create-perf-json.yml
+++ b/.github/workflows/create-perf-json.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
     - name: Checkout perfmon
-      uses: actions/checkout@v4
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Set up Python 3.x
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:
         python-version: "3.x"
 
@@ -36,7 +36,7 @@ jobs:
       run: python create_perf_json.py -v
 
     - name: Archive perf json files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
       with:
         name: perf-json
         path: scripts/perf


### PR DESCRIPTION
Instead of referencing versions, the guidance is to pin actions to a full length SHA corresponding to the release tag [1] [2]. Dependabot will continue to automatically monitor and open PRs for versions [3].

| Action                            | Old | New                    |
| --- | --- | --- |
| checkout                          | v4  | v4.1.1 release commit  |
| github-action-markdown-link-check | v1  | v1.0.15 release commit |
| setup-python                      | v5  | v5.0.0 release commit  |
| upload-artifact                   | v4  | v4.3.0 release commit  |

[1] https://securityscorecards.dev/viewer/?uri=github.com/intel/perfmon
[2] https://github.com/ossf/scorecard/blob/497b851040f18b6cacfbc67500b6fad98ac5e367/docs/checks.md#pinned-dependencies
[3] https://github.com/dependabot/dependabot-core/issues/4691