### PR TITLE
perf_format_converter: Refine event options expression

### DIFF
--- a/scripts/perf_format_converter.py
+++ b/scripts/perf_format_converter.py
@@ -300,7 +300,7 @@ class PerfFormatConverter:
                 if split[0] in event_info["translations"]:
                     translation += "\\\\," + event_info["translations"][split[0]] + "\\\\=" + "0x" + split[1]
             else:
-                match = re.match(r"([a-zA-z]+)([\d]+)", option)
+                match = re.match(r"([a-zA-Z]+)([\d]+)", option)
                 if match:
                     if match[1] in event_info["translations"]:
                         translation += "\\\\,"+ event_info["translations"][match[1]] + "\\\\=" + "0x" + match[2]


### PR DESCRIPTION
Restrict character range from A-z to A-Z. Characters such as [ are not valid matches. [Identified by CodeQL](https://github.com/intel/perfmon/security/code-scanning/1).

Examples of events passed into `translate_event_options()` before they are split on `:`.
```
UNC_C_TOR_INSERTS.OPCODE:opc=0x1c8:tid=0x3e
UOPS_ISSUED.ANY:c1
OFFCORE_REQUESTS_OUTSTANDING.DEMAND_DATA_RD:u0x10
UOPS_EXECUTED.CORE:i1:c1
```

