### PR TITLE
For perf converter, add some new fields for event grouping

### DIFF
--- a/scripts/create_perf_json.py
+++ b/scripts/create_perf_json.py
@@ -1760,10 +1760,12 @@ class Model:
                 json.dump(events_, perf_json, sort_keys=True, indent=4,
                           separators=(',', ': '))
                 perf_json.write('\n')
-        # Write units and counters data to counter.json file
-        output_counters = Path(outdir, 'counter.json')
-        with open(output_counters, 'w', encoding='ascii') as cnt_json:
-            json.dump(list(self.unit_counters.values()), cnt_json, indent=4)
+        # Skip hybrid because event grouping does not support it well yet
+        if self.shortname not in ['ADL', 'ADLN', 'MTL']:
+            # Write units and counters data to counter.json file
+            output_counters = Path(outdir, 'counter.json')
+            with open(output_counters, 'w', encoding='ascii') as cnt_json:
+                json.dump(list(self.unit_counters.values()), cnt_json, indent=4)
 
         metrics = []
         for metric_csv_key, unit in [('tma metrics', 'cpu_core'),

--- a/scripts/create_perf_json.py
+++ b/scripts/create_perf_json.py
@@ -304,6 +304,7 @@ class PerfmonJsonEvent:
         self.sample_after_value = get('SampleAfterValue')
         self.umask = get('UMask')
         self.unit = get('Unit')
+        self.counter = get('Counter')
         # Sanity check certain old perfmon keys or values that could
         # be used in perf json don't exist.
         assert 'Internal' not in jd
@@ -467,6 +468,7 @@ class PerfmonJsonEvent:
         add_to_result('SampleAfterValue', self.sample_after_value)
         add_to_result('UMask', self.umask)
         add_to_result('Unit', self.unit)
+        add_to_result('Counter', self.counter)
         return result
 
 def rewrite_metrics_in_terms_of_others(metrics: list[Dict[str,str]]) -> list[Dict[str,str]]:

--- a/scripts/create_perf_json.py
+++ b/scripts/create_perf_json.py
@@ -1586,7 +1586,9 @@ class Model:
         return jo
 
     def count_counters(self, event_type, pmon_events):
-        # Count number of counters in each PMU unit
+        """
+        Count number of counters in each PMU unit
+        """
 
         for event in pmon_events:
             if not event.counter or "FREERUN" in event.event_name:
@@ -1759,7 +1761,7 @@ class Model:
                           separators=(',', ': '))
                 perf_json.write('\n')
         # Write units and counters data to counter.json file
-        output_counters = Path(outdir, f'counter.json')
+        output_counters = Path(outdir, 'counter.json')
         with open(output_counters, 'w', encoding='ascii') as cnt_json:
             json.dump(list(self.unit_counters.values()), cnt_json, indent=4)
 

--- a/scripts/create_perf_json.py
+++ b/scripts/create_perf_json.py
@@ -1588,11 +1588,8 @@ class Model:
     def count_counters(self, event_type, pmon_events):
         # Count number of counters in each PMU unit
 
-        print(f"Event_type: {event_type}")
-        print(f"Number of events = {len(pmon_events)}")
         for event in pmon_events:
             if not event.counter or "FREERUN" in event.event_name:
-                print(event.event_name)
                 continue
             counters = event.counter.split(',')
             if "fixed" in counters[0].lower():


### PR DESCRIPTION
Sometimes we might want to only update and regenerate event files, so add a command option to skip the metric file processing and generate step. 

When we do event grouping base on hardware counter information, we need to know the list of counters an event could be collected on and also how many counters available on each Perfmon unit. Therefore, add several attributes and function to generate this type of info. This change will create a new file named `counter.json` locate together with all the event json files that includes Perfmon unit name and number of counters. 

A simple example of content in `counter.json`:

```
{
    {  
        "Unit": "core",
        "NumFixedCounters": "4",
        "NumCounters": "8"
    },
    {
        "Unit": "PCU",
        "NumFixedCounters": "0",
        "NumCounters": "4"
    },
    {
        "Unit": "IRP",
        "NumFixedCounters": "0",
        "NumCounters": "2"
    }
 ...
}
```