### PR TITLE
scripts: Update license and copyright

### DIFF
--- a/scripts/create_perf_json.py
+++ b/scripts/create_perf_json.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
 # REQUIREMENT: Install Python3 on your machine
 # USAGE: Run from command line with the following parameters -
 #

--- a/scripts/create_perf_json.py
+++ b/scripts/create_perf_json.py
@@ -1,3 +1,5 @@
+# Copyright (C) 2022 Intel Corporation
+# Copyright (C) 2022 Google
 # SPDX-License-Identifier: BSD-3-Clause
 
 # REQUIREMENT: Install Python3 on your machine

--- a/scripts/create_perf_json.py
+++ b/scripts/create_perf_json.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2022 Intel Corporation
-# Copyright (C) 2022 Google
+# Copyright (C) 2022 Google LLC
 # SPDX-License-Identifier: BSD-3-Clause
 
 # REQUIREMENT: Install Python3 on your machine

--- a/scripts/metric.py
+++ b/scripts/metric.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 Google
+# Copyright (C) 2022 Google LLC
 # SPDX-License-Identifier: BSD-3-Clause
 """Parse or generate representations of perf metrics."""
 import ast

--- a/scripts/metric.py
+++ b/scripts/metric.py
@@ -1,3 +1,4 @@
+# Copyright (C) 2022 Google
 # SPDX-License-Identifier: BSD-3-Clause
 """Parse or generate representations of perf metrics."""
 import ast

--- a/scripts/perf_format_converter.py
+++ b/scripts/perf_format_converter.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2021 Intel Corporation
+# Copyright (C) 2021 Google
 # SPDX-License-Identifier: BSD-3-Clause
 
 # REQUIREMENT: Install Python3 on your machine

--- a/scripts/perf_format_converter.py
+++ b/scripts/perf_format_converter.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021 Intel Corporation
-# Copyright (C) 2021 Google
+# Copyright (C) 2021 Google LLC
 # SPDX-License-Identifier: BSD-3-Clause
 
 # REQUIREMENT: Install Python3 on your machine

--- a/scripts/perf_format_converter.py
+++ b/scripts/perf_format_converter.py
@@ -1,28 +1,5 @@
 # Copyright (C) 2021 Intel Corporation
-#
-# Redistribution and use in source and binary forms, with or without modification,
-# are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-#    this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-#    this list of conditions and the following disclaimer in the documentation
-#    and/or other materials provided with the distribution.
-# 3. Neither the name of the copyright holder nor the names of its contributors
-#    may be used to endorse or promote products derived from this software
-#    without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
-# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-# OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
-# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
-# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
-# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# SPDX-License-Identifier: BSD-3-Clause
 
 # REQUIREMENT: Install Python3 on your machine
 # USAGE: Run from command line with the following parameters -

--- a/scripts/unittesting/metric_test.py
+++ b/scripts/unittesting/metric_test.py
@@ -1,3 +1,4 @@
+# Copyright (C) 2022 Google
 # SPDX-License-Identifier: BSD-3-Clause
 import os
 import sys

--- a/scripts/unittesting/metric_test.py
+++ b/scripts/unittesting/metric_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 Google
+# Copyright (C) 2022 Google LLC
 # SPDX-License-Identifier: BSD-3-Clause
 import os
 import sys

--- a/scripts/unittesting/test_perf_format_converter.py
+++ b/scripts/unittesting/test_perf_format_converter.py
@@ -1,28 +1,5 @@
 # Copyright (C) 2021 Intel Corporation
-#
-# Redistribution and use in source and binary forms, with or without modification,
-# are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-#    this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-#    this list of conditions and the following disclaimer in the documentation
-#    and/or other materials provided with the distribution.
-# 3. Neither the name of the copyright holder nor the names of its contributors
-#    may be used to endorse or promote products derived from this software
-#    without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
-# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-# OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
-# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
-# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
-# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
-# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# SPDX-License-Identifier: BSD-3-Clause
 
 
 import os


### PR DESCRIPTION
This pull request updates `scripts` headers. No license changes. Continues as BSD-3-Clause.

1. Add `SPDX-License-Identifier: BSD-3-Clause` if no license was present.
2. Use `SPDX-License-Identifier: BSD-3-Clause` in place of full license to standardize Python scripts. Full license text is located at https://github.com/intel/perfmon/blob/main/LICENSE .
3. Add `Copyright (C) ...` entries for all Python scripts.
4. Update Copyright notices based on contribution history.

