### PR TITLE
create_perf_json: Fix inefficient regex warning

### DIFF
--- a/.github/workflows/create-perf-json.yml
+++ b/.github/workflows/create-perf-json.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Run unittests
       working-directory: ./scripts/unittesting
-      run: python metric_test.py
+      run: python -m unittest metric_test.py test_create_perf_json.py
 
     - name: Create perf json files
       working-directory: ./scripts

--- a/scripts/unittesting/test_create_perf_json.py
+++ b/scripts/unittesting/test_create_perf_json.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+import unittest
+import sys
+from pathlib import Path
+
+# Add create_perf_json.py directory to the path before importing.
+_script_dir = Path(__file__).resolve().parent
+sys.path.append(str(_script_dir.parent))
+
+from create_perf_json import Model
+
+
+class TestModel(unittest.TestCase):
+
+    def test_extract_pebs_formula(self):
+        """Test formulas which use $PEBS but do not include min() or max()."""
+        tests = [
+            (
+                'EVENT.A*$PEBS',
+                '( EVENT.A * EVENT.A:R )',
+            ),
+            (
+                'EVENT.A + cpu_core@EVENT.B@*$PEBS',
+                'EVENT.A + ( cpu_core@EVENT.B@ * cpu_core@EVENT.B@R )',
+            ),
+        ]
+
+        for input, expected_result in tests:
+            with self.subTest(input=input, expected_result=expected_result):
+                self.assertEqual(expected_result, Model.extract_pebs_formula(input))
+
+    def test_extract_pebs_formula_with_min_max(self):
+        """Test formulas which use $PEBS and also min() or max()."""
+        tests = [
+            (
+                'EVENT.A*min( $PEBS, 4) / EVENT.B',
+                'EVENT.A * min(EVENT.A:R, 4) / EVENT.B',
+            ),
+            (
+                'EVENT.A*min($PEBS, 2) / (1 + EVENT.B*max($PEBS, 8))',
+                'EVENT.A * min(EVENT.A:R, 2) / (1 + EVENT.B * max(EVENT.B:R, 8))',
+            ),
+            (
+                'EVENT.A*min($PEBS, 9 * test_info) * (1 + (cpu_core@EVENT.B@ / cpu_core@EVENT.C@) / 2) / test_info_2',
+                'EVENT.A * min(EVENT.A:R, 9 * test_info) * (1 + (cpu_core@EVENT.B@ / cpu_core@EVENT.C@) / 2) / test_info_2',
+            ),
+            (
+                '(cpu_core@EVENT.A@*min($PEBS, 24 * test_info) + cpu_core@EVENT.B@*min($PEBS, 24 - test_info) * (1 - (cpu_core@EVENT.C@ / (cpu_core@EVENT.D@ + cpu_core@EVENT.E@)))) * 5',
+                '(cpu_core@EVENT.A@ * min(cpu_core@EVENT.A@R, 24 * test_info) + cpu_core@EVENT.B@ * min(cpu_core@EVENT.B@R, 24 - test_info) * (1 - (cpu_core@EVENT.C@ / (cpu_core@EVENT.D@ + cpu_core@EVENT.E@)))) * 5',
+            )
+        ]
+
+        for input, expected_result in tests:
+            with self.subTest(input=input, expected_result=expected_result):
+                self.assertEqual(expected_result, Model.extract_pebs_formula(input))


### PR DESCRIPTION
The primary goal of this commit is to address an inefficient regex identified by CodeQL https://github.com/intel/perfmon/security/code-scanning/6. The goal of the `MIN_MAX_PEBS` expression is to extract groups for the leading event name, `$PEBS` in the first function argument, and the alternative function argument. The following are example formula snippets.
```
MEM_INST_RETIRED.STLB_HIT_LOADS*min($PEBS, 7)
cpu_core@MEM_LOAD_L3_HIT_RETIRED.XSNP_MISS@*min($PEBS, 24 * tma_info_system_core_frequency)
MEM_INST_RETIRED.SPLIT_LOADS*min($PEBS, tma_info_memory_load_miss_real_latency)
```

`$PEBS` is replaced with the event name and a trailing `:R` or `R`.
```
Input:  EVENT.A*min($PEBS, 4)
Output: EVENT.A * min(EVENT.A:R, 4)
```
```
Input:  cpu_core@EVENT.B@*min($PEBS, 24 * tma_info_system_core_frequency)
Output: cpu_core@EVENT.B@ * min(cpu_core@EVENT.B@R, 24 * tma_info_system_core_frequency)
```

Regular expression changes:
 - Replace `\s` any whitespace character, with a simple space.
 - Remove unnecessary escapes inside character classes to simplify.
 - Replace the second argument (alternative) group pattern with a character class for lower case letters, numbers, spaces, underscores, and math operations.