### PR TITLE
ci: Bandit updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-bandit[sarif]
+bandit[sarif]==1.7.9

--- a/scripts/ci/verify_mapfile/requirements.txt
+++ b/scripts/ci/verify_mapfile/requirements.txt
@@ -1,1 +1,1 @@
-jsonschema
+jsonschema==4.23.0

--- a/scripts/metric.py
+++ b/scripts/metric.py
@@ -562,7 +562,7 @@ def ParsePerfJson(orig: str) -> Expression:
     raise SyntaxError(f'Parsing expression:\n{orig}') from e
   _RewriteIfExpToSelect().visit(parsed)
   parsed = ast.fix_missing_locations(parsed)
-  return _Constify(eval(compile(parsed, orig, 'eval')))
+  return _Constify(eval(compile(parsed, orig, 'eval'))) #nosec B307
 
 
 def RewriteMetricsInTermsOfOthers(metrics: list[Tuple[str, Expression]]


### PR DESCRIPTION
* Bandit is flagging eval() as a possible issue [#7](https://github.com/intel/perfmon/security/code-scanning/7) . In this instance, usage is already ignored for pylint.
* Automated scanning recommends pinning requirements.txt packages to a specific version https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies .