### PR TITLE
Fix PMU for UNC_CLOCK.SOCKET on BDW, HSW, SKL

### DIFF
--- a/scripts/create_perf_json.py
+++ b/scripts/create_perf_json.py
@@ -176,6 +176,7 @@ def topic(event_name: str, unit: str) -> str:
             'cha': 'Uncore-Cache',
             'chacms': 'Uncore-Cache',
             'cbox': 'Uncore-Cache',
+            'cbox_0': 'Uncore-Cache',
             'ha': 'Uncore-Cache',
             'hac_cbo': 'Uncore-Cache',
             'b2cxl': 'Uncore-CXL',
@@ -342,7 +343,7 @@ class PerfmonJsonEvent:
             if self.unit in unit_fixups:
                 self.unit = unit_fixups[self.unit]
             elif self.unit == "NCU" and self.event_name == "UNC_CLOCK.SOCKET":
-                self.unit = "CLOCK"
+                self.unit = "cbox_0" if shortname in ['BDW', 'HSW', 'SKL'] else "CLOCK"
             elif self.event_name.startswith("UNC_P_POWER_STATE_OCCUPANCY"):
                 # Older uncore_pcu PMUs don't have a umask, fix to occ_sel.
                 assert self.unit == "PCU"


### PR DESCRIPTION
The PMU uncore_clock isn't present on Skylake and earlier machines. The event is present on cbox_0 (note, the suffix is included to avoid multiple cbox PMUs being added together).


Note, are the event encodings for BDW/HDW/SKL cbox_0 correct in this context? The json shows:
      "EventCode": "0x0",
      "UMask": "0x01",
but this maybe should be "event=0xff,umask=0x00". As uncore_clock isn't present on these models perf currently doesn't report this event.