### PR TITLE
Fix tma_heavy_operations_group for Skylake

### DIFF
--- a/scripts/create_perf_json.py
+++ b/scripts/create_perf_json.py
@@ -1414,7 +1414,9 @@ class Model:
                     # Metrics that would fit were the NMI watchdog disabled.
                     'tma_dtlb_load': nmi,
                     'tma_fb_full': nmi,
+                    'tma_few_uops_instructions': nmi,
                     'tma_load_stlb_hit': nmi,
+                    'tma_microcode_sequencer': nmi,
                     'tma_remote_cache': nmi,
                     'tma_split_loads': nmi,
                     'tma_store_latency': nmi,


### PR DESCRIPTION
The metrics tma_few_uops_instructions and tma_microcode_sequencer require all 6 counters, therefore the metric can't succeed if the NMI watchdog is enabled. Update the constraints so that if the NMI watchdog is enabled the events won't be grouped.