### PR TITLE
mapfile: Add ARL-H

### DIFF
--- a/mapfile.csv
+++ b/mapfile.csv
@@ -207,6 +207,10 @@ GenuineIntel-6-B6,V0,/GRR/metrics/grandridge_metrics.json,metrics,,,
 GenuineIntel-6-BD,V1.06,/LNL/events/lunarlake_skymont_core.json,hybridcore,0x20,0x000003,Atom
 GenuineIntel-6-BD,V1.06,/LNL/events/lunarlake_lioncove_core.json,hybridcore,0x40,0x000003,Core
 GenuineIntel-6-BD,V1.06,/LNL/events/lunarlake_uncore.json,uncore,,,
+GenuineIntel-6-C5,V1.03,/ARL/events/arrowlake_skymont_core.json,hybridcore,0x20,0x000003,Atom
+GenuineIntel-6-C5,V1.03,/ARL/events/arrowlake_crestmont_core.json,hybridcore,0x20,0x000002,LowPower_Atom
+GenuineIntel-6-C5,V1.03,/ARL/events/arrowlake_lioncove_core.json,hybridcore,0x40,0x000003,Core
+GenuineIntel-6-C5,V1.03,/ARL/events/arrowlake_uncore.json,uncore,,,
 GenuineIntel-6-C6,V1.03,/ARL/events/arrowlake_skymont_core.json,hybridcore,0x20,0x000003,Atom
 GenuineIntel-6-C6,V1.03,/ARL/events/arrowlake_lioncove_core.json,hybridcore,0x40,0x000003,Core
 GenuineIntel-6-C6,V1.03,/ARL/events/arrowlake_uncore.json,uncore,,,

--- a/scripts/ci/verify_mapfile/mapfile_schema.json
+++ b/scripts/ci/verify_mapfile/mapfile_schema.json
@@ -32,7 +32,7 @@
             },
             "Core Role Name" : {
                 "type": "string",
-                "pattern": "^(Core|Atom)?$"
+                "pattern": "^(Core|Atom|LowPower_Atom)?$"
             }
         },
         "required" : [

--- a/scripts/ci/verify_mapfile/verify_mapfile.py
+++ b/scripts/ci/verify_mapfile/verify_mapfile.py
@@ -254,22 +254,25 @@ def verify_mapfile_duplicate_types(perfmon_repo_path: Path):
         # Filter for any rows with a matching model.
         mapfile_rows = [x for x in mapfile_data if x['Family-model'] == model]
 
-        # Create a dict key based on EventType and Core Type. Otherwise, for hybrid platforms
-        # there would be overlapping entries for 'hybridcore'. Combinations of 'hybridcore'
-        # and core type should be unique.
-        event_and_core_types = {}
+        # Create a dict key based on EventType. For hybrid platforms also include Core Type
+        # and Native Model ID otherwise there would be overlapping entries for 'hybridcore'.
+        unique_entry_check = {}
         for row in mapfile_rows:
             event_type = row['EventType']
             core_type = row['Core Type']
-            key = f'{event_type}_{core_type}'
+            native_model_id = row['Native Model ID']
+
+            key = f'{event_type}'
+            if event_type == 'hybridcore':
+                key = f'{event_type}_{core_type}_{native_model_id}'
 
             # This row already existed if the key is present.
-            if key in event_and_core_types:
-                msg = (f'Family-model {model} includes duplicate entry for EventType={event_type} and '
-                       f'Core Type={core_type}.')
+            if key in unique_entry_check:
+                msg = (f'Family-model {model} includes duplicate entry for EventType {event_type}. '
+                       f'Mapfile row {row}.')
                 raise RuntimeError(msg)
 
-            event_and_core_types[key] = 1
+            unique_entry_check[key] = 1
 
 
 def verify_mapfile_model_event_versions(perfmon_repo_path: Path):

--- a/scripts/create_perf_json.py
+++ b/scripts/create_perf_json.py
@@ -172,7 +172,7 @@ def topic(event_name: str, unit: str) -> str:
     @param event_name: Name of event like UNC_M2M_BYPASS_M2M_Egress.NOT_TAKEN.
     @param unit: The PMU responsible for the event or None for CPU events.
     """
-    if unit and unit not in ['cpu', 'cpu_atom', 'cpu_core']:
+    if unit and unit not in ['cpu', 'cpu_atom', 'cpu_core', 'cpu_lowpower']:
         unit_to_topic = {
             'cha': 'Uncore-Cache',
             'chacms': 'Uncore-Cache',
@@ -1642,13 +1642,15 @@ class Model:
         # representing the perf json event. The dictionary events may
         # be modified by the uncore CSV file.
         dict_events: Dict[str, Dict[str, str]] = {}
-        for event_type in ['atom', 'core', 'uncore', 'uncore experimental']:
+        for event_type in ['atom', 'core', 'lowpower', 'uncore', 'uncore experimental']:
             if event_type not in self.files:
                 continue
             _verboseprint2(f'Generating {event_type} events from {self.files[event_type]}')
             pmu_prefix = None
-            if event_type in ['atom', 'core']:
-                pmu_prefix = f'cpu_{event_type}' if 'atom' in self.files else 'cpu'
+            if event_type in ['atom', 'core', 'lowpower']:
+                pmu_prefix = 'cpu'
+                if 'atom' in self.files or 'lowpower' in self.files:
+                    pmu_prefix = f'cpu_{event_type}'
             with open(self.files[event_type], 'r') as event_json:
                 json_data = json.load(event_json)
                 # UNC_IIO_BANDWIDTH_OUT events are broken on Linux pre-SPR so skip if they exist.
@@ -1658,8 +1660,11 @@ class Model:
                                if self.shortname == 'SPR' or
                                not x["EventName"].startswith("UNC_IIO_BANDWIDTH_OUT.")]
                 unit = None
-                if event_type in ['atom', 'core'] and 'atom' in self.files and 'core' in self.files:
-                    unit = f'cpu_{event_type}'
+                if event_type in ['atom', 'core', 'lowpower']:
+                    # If the platform is a hybrid there will be a combination of atom,
+                    # lowpower (LowPower_Atom), or core files.
+                    if ('atom' in self.files or 'lowpower' in self.files) and 'core' in self.files:
+                        unit = f'cpu_{event_type}'
                 per_pkg = '1' if event_type in ['uncore', 'uncore experimental'] else None
                 duplicates: Set[str] = set()
                 for event in pmon_events:
@@ -1890,8 +1895,16 @@ class Mapfile:
 
                 if event_type == 'hybridcore':
                     # We want a core and an atom file, so change
-                    # event_type for hybrid models.
-                    event_type = 'core' if core_role_name == 'Core' else 'atom'
+                    # event_type for hybrid models. Mapfile.csv core
+                    # roles are Core, Atom, or LowPower_Atom.
+                    core_role_mapfile_to_linux_mapping = {
+                        'Core': 'core',
+                        'Atom': 'atom',
+                        'LowPower_Atom': 'lowpower',
+                    }
+                    if core_role_name not in core_role_mapfile_to_linux_mapping:
+                        raise ValueError(f'Unexpected core role {core_role_name}')
+                    event_type = core_role_mapfile_to_linux_mapping[core_role_name]
 
                 if shortname == 'KNM':
                     # The files for KNL and KNM are the same as are


### PR DESCRIPTION
This commit adds ARL-H model ID 0xC5 (https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/include/asm/intel-family.h) to `mapfile.csv`. Crestmont event content and updates were merged in https://github.com/intel/perfmon/pull/229 .

