### PR TITLE
create_perf_json: Add pcu_0 to event check ignores

### DIFF
--- a/scripts/create_perf_json.py
+++ b/scripts/create_perf_json.py
@@ -731,7 +731,7 @@ class Model:
                      'num_packages', 'num_cores', 'SYSTEM_TSC_FREQ',
                      'filter_tid', 'TSC', 'cha', 'config1',
                      'source_count', 'slots', 'thresh', 'has_pmem',
-                     'num_dies', 'num_cpus_online', 'PEBS', 'R',
+                     'num_dies', 'num_cpus_online', 'PEBS', 'pcu_0', 'R',
                      'offcore_rsp']:
                 continue
             if v.startswith('tma_') or v.startswith('topdown\\-'):


### PR DESCRIPTION
GitHub actions running `create_perf_json.py` are currently failing. This commit is a quick follow-up to metrics added in https://github.com/intel/perfmon/pull/250 . Ignores handle equations such as the following.

```
cbox_0@event\=0x0@
cha_0@event\=0x0@
imc_0@event\=0x0@
pcu_0@UNC_P_CLOCKTICKS@
```