### PR TITLE
dependabot: Ignore patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 1
+    ignore:
+      # Ignore patch updates (major.minor.patch) for all packages. This
+      # does not prevent security updates.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
   # Enable version updates from GitHub Actions.
   - package-ecosystem: "github-actions"
@@ -15,3 +20,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 1
+    ignore:
+      # Ignore patch updates (major.minor.patch) for all packages. This
+      # does not prevent security updates.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
This commit ignores Python and GitHub Action patch updates. Major and minor versions will still trigger an update. Security updates are not changed. It is noisy to update packages for every `patch` in `major.minor.patch`. Focusing on `major` and `minor` will provide sufficient updates for packages used in this project.

* https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#specifying-dependencies-and-versions-to-ignore