### PR TITLE
create_perf_json: Fix missing 'r' in power_uncore_fixups

### DIFF
--- a/scripts/create_perf_json.py
+++ b/scripts/create_perf_json.py
@@ -1365,9 +1365,9 @@ class Model:
                         ('UNC_C_CLOCKTICKS:one_unit', r'cbox_0@event\=0x0@'),
                     ]
                     power_uncore_fixups = [
-                        ('UNC_PKG_ENERGY_STATUS', 'power@energy\-pkg@'),
-                        ('FREERUN_PKG_ENERGY_STATUS', 'power@energy\-pkg@'),
-                        ('FREERUN_DRAM_ENERGY_STATUS', 'power@energy\-ram@'),
+                        ('UNC_PKG_ENERGY_STATUS', r'power@energy\-pkg@'),
+                        ('FREERUN_PKG_ENERGY_STATUS', r'power@energy\-pkg@'),
+                        ('FREERUN_DRAM_ENERGY_STATUS', r'power@energy\-ram@'),
                     ]
                     arch_fixups = {
                         'ADL': td_event_fixups + [


### PR DESCRIPTION
create_perf_json.py is generating these warnings:

.../scripts/./create_perf_json.py:1368: SyntaxWarning: invalid escape sequence '\-'
  ('UNC_PKG_ENERGY_STATUS', 'power@energy\-pkg@'),
.../perfmon/scripts/./create_perf_json.py:1369: SyntaxWarning: invalid escape sequence '\-'
  ('FREERUN_PKG_ENERGY_STATUS', 'power@energy\-pkg@'),
.../perfmon/scripts/./create_perf_json.py:1370: SyntaxWarning: invalid escape sequence '\-'
  ('FREERUN_DRAM_ENERGY_STATUS', 'power@energy\-ram@'),

Guessing that an 'r' prefix was missed here.