### PR TITLE
GNR cstate metric update

### DIFF
--- a/GNR/metrics/perf/graniterapids_metrics_perf.json
+++ b/GNR/metrics/perf/graniterapids_metrics_perf.json
@@ -311,18 +311,16 @@
         "ScaleUnit": "1MB/s"
     },
     {
-        "BriefDescription": "Percent of time that cores are in cstate C0 as observed by the power control unit (PCU)",
-        "MetricExpr": "100 * ((UNC_P_POWER_STATE_OCCUPANCY_CORES_C0 / (pcu_0@UNC_P_CLOCKTICKS@ / #num_packages ) ) / ( #num_cores / #num_packages * #num_packages ) )",
+        "BriefDescription": "The average number of cores that are in cstate C0 as observed by the power control unit (PCU)",
+        "MetricExpr": "(UNC_P_POWER_STATE_OCCUPANCY_CORES_C0 / UNC_P_CLOCKTICKS[0]) * #num_packages",
         "MetricGroup": "cpu_cstate",
-        "MetricName": "cpu_cstate_c0",
-	"ScaleUnit": "100%"
+        "MetricName": "cpu_cstate_c0"
     },
     {
-        "BriefDescription": "Percent of time that cores are in cstate C6 as observed by the power control unit (PCU)",
-        "MetricExpr": "100 * ((UNC_P_POWER_STATE_OCCUPANCY_CORES_C6 / (pcu_0@UNC_P_CLOCKTICKS@ / #num_packages ) ) / ( #num_cores / #num_packages * #num_packages ) )",
+        "BriefDescription": "The average number of cores are in cstate C6 as observed by the power control unit (PCU)",
+        "MetricExpr": "(UNC_P_POWER_STATE_OCCUPANCY_CORES_C6 / UNC_P_CLOCKTICKS[0]) * #num_packages",
         "MetricGroup": "cpu_cstate",
-        "MetricName": "cpu_cstate_c6",
-	"ScaleUnit": "100%"
+        "MetricName": "cpu_cstate_c6"
     },
     {
         "BriefDescription": "Total pipeline cost of Branch Misprediction related bottlenecks",


### PR DESCRIPTION
Changing GNR C-state metrics to report number of cores rather than percentage.