### PR TITLE
Fixing cstate metric syntax for perf

### DIFF
--- a/GNR/metrics/perf/graniterapids_metrics_perf.json
+++ b/GNR/metrics/perf/graniterapids_metrics_perf.json
@@ -312,13 +312,13 @@
     },
     {
         "BriefDescription": "The average number of cores that are in cstate C0 as observed by the power control unit (PCU)",
-        "MetricExpr": "(UNC_P_POWER_STATE_OCCUPANCY_CORES_C0 / UNC_P_CLOCKTICKS[0]) * #num_packages",
+        "MetricExpr": "(UNC_P_POWER_STATE_OCCUPANCY_CORES_C0 / pcu_0@UNC_P_CLOCKTICKS@) * #num_packages",
         "MetricGroup": "cpu_cstate",
         "MetricName": "cpu_cstate_c0"
     },
     {
         "BriefDescription": "The average number of cores are in cstate C6 as observed by the power control unit (PCU)",
-        "MetricExpr": "(UNC_P_POWER_STATE_OCCUPANCY_CORES_C6 / UNC_P_CLOCKTICKS[0]) * #num_packages",
+        "MetricExpr": "(UNC_P_POWER_STATE_OCCUPANCY_CORES_C6 / pcu_0@UNC_P_CLOCKTICKS@) * #num_packages",
         "MetricGroup": "cpu_cstate",
         "MetricName": "cpu_cstate_c6"
     },


### PR DESCRIPTION
Adding yet another fix for cstate metric.
"UNC_P_CLOCKTICKS[0]" needs to be converted to "pcu_0@UNC_P_CLOCKTICKS@".