### PR TITLE
create_perf_json: Expose PDIST Counter information

### DIFF
--- a/scripts/create_perf_json.py
+++ b/scripts/create_perf_json.py
@@ -389,6 +389,11 @@ class PerfmonJsonEvent:
             self.event_code = "0xff"
             self.umask = None
 
+        if "PDISTCounter" in jd:
+           self.pdist_counter = jd.get('PDISTCounter').strip()
+        else:
+           self.pdist_counter = "NA"
+
         if self.filter:
             remove_filter_start = [
                 "cbofilter",
@@ -489,6 +494,7 @@ class PerfmonJsonEvent:
         add_to_result('UMask', self.umask)
         add_to_result('Unit', self.unit)
         add_to_result('Counter', self.counter)
+        add_to_result('PDISTCounter', self.pdist_counter)
         if self.experimental:
             add_to_result("Experimental", '1')
         return result


### PR DESCRIPTION
The generic PDIST availability information can only be found in the SDM. Also, some events may not support PDIST. It's hard to find that information either.

Expose the PDIST information in the event list.

The new field PDISTCounter indicates the event's available PDIST counters. '0' is valid counter index.
For the events which don't support PDIST, "NA" is filled.