### PR TITLE
create_perf_json: Expose PDIST Counter information in PublicDescription

### DIFF
--- a/scripts/create_perf_json.py
+++ b/scripts/create_perf_json.py
@@ -420,6 +420,11 @@ class PerfmonJsonEvent:
         if not self.public_description:
             self.public_description = get('Description')
 
+        if "PDISTCounter" in jd:
+            pdist_counter = jd.get('PDISTCounter').strip()
+            if pdist_counter != 'NA':
+                self.public_description += " Available PDIST counters: " + pdist_counter
+
         # The public description is the longer, if it is already
         # contained within or equals the brief description then it is
         # redundant.


### PR DESCRIPTION
The generic PDIST availability information can only be found in the SDM. Also, some events may not support PDIST. It's hard to find that information either.

Append the PDIST information into the PublicDescription of the event list, if it's available.

If the event or platform doesn't support PDIST, nothing is changed.

The PDIST Counter information may be useful for the hardware-aware grouping of Linux perf. But the hardware-aware grouping only works for perf stat for now. There is no plan to enable the hardware-aware grouping for perf record shortly. Adding a dedicated PDIST field is unnecessary.