### PR TITLE
create_perf_json: workaround event grouping issues for some hybrid me…

### DIFF
--- a/scripts/create_perf_json.py
+++ b/scripts/create_perf_json.py
@@ -940,6 +940,10 @@ class Model:
             # Metrics with more events than counters.
             'tma_info_system_mem_read_latency': no_group,
             'tma_info_system_mem_request_latency': no_group,
+            'tma_l2_hit_latency': no_group,
+            'tma_l3_hit_latency': no_group,
+            'tma_data_sharing': no_group,
+            'tma_contested_accesses': no_group,
             # Metrics that would fit were the NMI watchdog disabled.
             'tma_ports_utilized_2': nmi,
             'tma_ports_utilized_3m': nmi,


### PR DESCRIPTION
…trics

Resolves issues with some metrics on arrow lake which are causing failures in perf tool metrics tests.

$ sudo ./perf stat -M tma_l2_hit_latency -a true
WARNING: grouped events cpus do not match.
Events with CPUs not matching the leader will be removed from the group.
  anon group { cpu_core/TOPDOWN.SLOTS/, cpu_core/topdown-retiring/, cpu_core/MEMORY_STALLS.L2/, cpu_core/topdown-mem-bound/, cpu_core/topdown-bad-spec/, cpu_core/MEM_LOAD_RETIRED.L1_MISS/, cpu_core/CPU

 Performance counter stats for 'system wide':

     <not counted>      cpu_core/TOPDOWN.SLOTS/                                               
     <not counted>      cpu_core/topdown-retiring/                                            
     <not counted>      cpu_core/MEMORY_STALLS.L2/                                            
     <not counted>      cpu_core/topdown-mem-bound/                                           
     <not counted>      cpu_core/topdown-bad-spec/                                            
     <not counted>      cpu_core/MEM_LOAD_RETIRED.L1_MISS/                                      
     <not counted>      cpu_core/CPU_CLK_UNHALTED.THREAD/                                      
     <not counted>      cpu_core/MEM_LOAD_RETIRED.L2_HIT/                                      
       142,484,516      TSC                                                                   
     <not counted>      cpu_core/MEM_LOAD_RETIRED.FB_HIT/                                      
     <not counted>      cpu_core/topdown-fe-bound/                                            
     <not counted>      cpu_core/CPU_CLK_UNHALTED.REF_TSC/                                      
     <not counted>      cpu_core/topdown-be-bound/                                            
                 0      cpu_core/MEM_LOAD_RETIRED.L2_HIT/R                                      
         3,260,025      duration_time                                                         

       0.002071082 seconds time elapsed

