### PR TITLE
create_perf_json: specify cpu type in TSC metric

### DIFF
--- a/scripts/create_perf_json.py
+++ b/scripts/create_perf_json.py
@@ -1971,6 +1971,18 @@ class Model:
 
         if len(metrics) > 0:
             metrics.extend(self.cstate_json())
+
+            for m in metrics:
+                form = m['MetricExpr']
+                if "TSC" in form:
+                    if 'Unit' in m:
+                        unit = m['Unit']
+                        tsc_pmu_suffix = rf"\,cpu={unit}@"
+                    else:
+                        tsc_pmu_suffix = "@"
+                    form = re.sub(r"\bTSC\b", "msr@tsc" + tsc_pmu_suffix, form)
+                    m['MetricExpr'] = form
+
             mg = self.tsx_json()
             if mg:
                 metrics.extend(json.loads(mg.ToPerfJson()))


### PR DESCRIPTION
Replace "TSC" with "msr/tsc" or "msr/tsc,cpu=<cpu type>" to specify global or cpu type specific TSC metric.