### PR TITLE
SPR_EMR_cstate_metric_update

### DIFF
--- a/EMR/metrics/emeraldrapids_metrics.json
+++ b/EMR/metrics/emeraldrapids_metrics.json
@@ -1115,7 +1115,7 @@
           "Alias": "socket_count"
         }
       ],
-      "Formula": "(b / a[0]) * socket_count",
+      "Formula": "(b / a) * socket_count",
       "Category": "Power",
       "ResolutionLevels": "SOCKET, SYSTEM",
       "MetricGroup": "cpu_cstate"
@@ -1142,7 +1142,7 @@
           "Alias": "socket_count"
         }
       ],
-      "Formula": "(b / a[0]) * socket_count",
+      "Formula": "(b / a) * socket_count",
       "Category": "Power",
       "ResolutionLevels": "SOCKET, SYSTEM",
       "MetricGroup": "cpu_cstate"

--- a/EMR/metrics/perf/emeraldrapids_metrics_perf.json
+++ b/EMR/metrics/perf/emeraldrapids_metrics_perf.json
@@ -321,13 +321,13 @@
     },
     {
         "BriefDescription": "The average number of cores that are in cstate C0 as observed by the power control unit (PCU)",
-        "MetricExpr": "( UNC_P_POWER_STATE_OCCUPANCY_CORES_C0 / pcu_0@UNC_P_CLOCKTICKS@ ) * #num_packages",
+        "MetricExpr": "( UNC_P_POWER_STATE_OCCUPANCY_CORES_C0 / UNC_P_CLOCKTICKS ) * #num_packages",
         "MetricGroup": "cpu_cstate",
         "MetricName": "cpu_cstate_c0"
     },
     {
         "BriefDescription": "The average number of cores are in cstate C6 as observed by the power control unit (PCU)",
-        "MetricExpr": "( UNC_P_POWER_STATE_OCCUPANCY_CORES_C6 / pcu_0@UNC_P_CLOCKTICKS@ ) * #num_packages",
+        "MetricExpr": "( UNC_P_POWER_STATE_OCCUPANCY_CORES_C6 / UNC_P_CLOCKTICKS ) * #num_packages",
         "MetricGroup": "cpu_cstate",
         "MetricName": "cpu_cstate_c6"
     }

--- a/SPR/metrics/perf/sapphirerapids_metrics_perf.json
+++ b/SPR/metrics/perf/sapphirerapids_metrics_perf.json
@@ -398,13 +398,13 @@
     },
     {
         "BriefDescription": "The average number of cores that are in cstate C0 as observed by the power control unit (PCU)",
-        "MetricExpr": "( UNC_P_POWER_STATE_OCCUPANCY_CORES_C0 / pcu_0@UNC_P_CLOCKTICKS@ ) * #num_packages",
+        "MetricExpr": "( UNC_P_POWER_STATE_OCCUPANCY_CORES_C0 / UNC_P_CLOCKTICKS ) * #num_packages",
         "MetricGroup": "cpu_cstate",
         "MetricName": "cpu_cstate_c0"
     },
     {
         "BriefDescription": "The average number of cores are in cstate C6 as observed by the power control unit (PCU)",
-        "MetricExpr": "( UNC_P_POWER_STATE_OCCUPANCY_CORES_C6 / pcu_0@UNC_P_CLOCKTICKS@ ) * #num_packages",
+        "MetricExpr": "( UNC_P_POWER_STATE_OCCUPANCY_CORES_C6 / @UNC_P_CLOCKTICKS ) * #num_packages",
         "MetricGroup": "cpu_cstate",
         "MetricName": "cpu_cstate_c6"
     }

--- a/SPR/metrics/perf/sapphirerapidshbm_metrics_perf.json
+++ b/SPR/metrics/perf/sapphirerapidshbm_metrics_perf.json
@@ -398,13 +398,13 @@
     },
     {
         "BriefDescription": "The average number of cores that are in cstate C0 as observed by the power control unit (PCU)",
-        "MetricExpr": "( UNC_P_POWER_STATE_OCCUPANCY_CORES_C0 / pcu_0@UNC_P_CLOCKTICKS@ ) * #num_packages",
+        "MetricExpr": "( UNC_P_POWER_STATE_OCCUPANCY_CORES_C0 / UNC_P_CLOCKTICKS ) * #num_packages",
         "MetricGroup": "cpu_cstate",
         "MetricName": "cpu_cstate_c0"
     },
     {
         "BriefDescription": "The average number of cores are in cstate C6 as observed by the power control unit (PCU)",
-        "MetricExpr": "( UNC_P_POWER_STATE_OCCUPANCY_CORES_C6 / pcu_0@UNC_P_CLOCKTICKS@ ) * #num_packages",
+        "MetricExpr": "( UNC_P_POWER_STATE_OCCUPANCY_CORES_C6 / UNC_P_CLOCKTICKS ) * #num_packages",
         "MetricGroup": "cpu_cstate",
         "MetricName": "cpu_cstate_c6"
     }

--- a/SPR/metrics/sapphirerapids_metrics.json
+++ b/SPR/metrics/sapphirerapids_metrics.json
@@ -1334,7 +1334,7 @@
           "Alias": "socket_count"
         }
       ],
-      "Formula": "(b / a[0]) * socket_count",
+      "Formula": "(b / a) * socket_count",
       "Category": "Power",
       "ResolutionLevels": "SOCKET, SYSTEM",
       "MetricGroup": "cpu_cstate"
@@ -1361,7 +1361,7 @@
           "Alias": "socket_count"
         }
       ],
-      "Formula": "(b / a[0]) * socket_count",
+      "Formula": "(b / a) * socket_count",
       "Category": "Power",
       "ResolutionLevels": "SOCKET, SYSTEM",
       "MetricGroup": "cpu_cstate"

--- a/SPR/metrics/sapphirerapidshbm_metrics.json
+++ b/SPR/metrics/sapphirerapidshbm_metrics.json
@@ -1334,7 +1334,7 @@
           "Alias": "socket_count"
         }
       ],
-      "Formula": "(b / a[0]) * socket_count",
+      "Formula": "(b / a) * socket_count",
       "Category": "Power",
       "ResolutionLevels": "SOCKET, SYSTEM",
       "MetricGroup": "cpu_cstate"
@@ -1361,7 +1361,7 @@
           "Alias": "socket_count"
         }
       ],
-      "Formula": "(b / a[0]) * socket_count",
+      "Formula": "(b / a) * socket_count",
       "Category": "Power",
       "ResolutionLevels": "SOCKET, SYSTEM",
       "MetricGroup": "cpu_cstate"


### PR DESCRIPTION
Removing array notation for UNC_P_CLOCKTICKS references.