### PR TITLE
SPR: Trim extra @ sign from C6 metric

### DIFF
--- a/SPR/metrics/perf/sapphirerapids_metrics_perf.json
+++ b/SPR/metrics/perf/sapphirerapids_metrics_perf.json
@@ -404,7 +404,7 @@
     },
     {
         "BriefDescription": "The average number of cores are in cstate C6 as observed by the power control unit (PCU)",
-        "MetricExpr": "( UNC_P_POWER_STATE_OCCUPANCY_CORES_C6 / @UNC_P_CLOCKTICKS ) * #num_packages",
+        "MetricExpr": "( UNC_P_POWER_STATE_OCCUPANCY_CORES_C6 / UNC_P_CLOCKTICKS ) * #num_packages",
         "MetricGroup": "cpu_cstate",
         "MetricName": "cpu_cstate_c6"
     }


### PR DESCRIPTION
This commit is a quick follow-up to #340 .