### PR TITLE
mapfile: Remove 0 padding

### DIFF
--- a/mapfile.csv
+++ b/mapfile.csv
@@ -250,9 +250,9 @@ GenuineIntel-6-DD,V1.04,/CWF/events/clearwaterforest_core.json,core,,,
 GenuineIntel-6-DD,V1.04,/CWF/events/clearwaterforest_uncore.json,uncore,,,
 GenuineIntel-6-DD,V1.04,/CWF/events/clearwaterforest_uncore_experimental.json,uncore experimental,,,
 GenuineIntel-6-DD,V1.0,/CWF/metrics/clearwaterforest_metrics.json,metrics,,,
-GenuineIntel-18-01,V1.00,/NVL/events/novalake_arcticwolf_core.json,hybridcore,0x20,0x000005,Atom
-GenuineIntel-18-01,V1.00,/NVL/events/novalake_coyotecove_core.json,hybridcore,0x40,0x000005,Core
-GenuineIntel-18-01,V1.00,/NVL/events/novalake_uncore.json,uncore,,,
-GenuineIntel-18-03,V1.00,/NVL/events/novalake_arcticwolf_core.json,hybridcore,0x20,0x000005,Atom
-GenuineIntel-18-03,V1.00,/NVL/events/novalake_coyotecove_core.json,hybridcore,0x40,0x000005,Core
-GenuineIntel-18-03,V1.00,/NVL/events/novalake_uncore.json,uncore,,,
+GenuineIntel-18-1,V1.00,/NVL/events/novalake_arcticwolf_core.json,hybridcore,0x20,0x000005,Atom
+GenuineIntel-18-1,V1.00,/NVL/events/novalake_coyotecove_core.json,hybridcore,0x40,0x000005,Core
+GenuineIntel-18-1,V1.00,/NVL/events/novalake_uncore.json,uncore,,,
+GenuineIntel-18-3,V1.00,/NVL/events/novalake_arcticwolf_core.json,hybridcore,0x20,0x000005,Atom
+GenuineIntel-18-3,V1.00,/NVL/events/novalake_coyotecove_core.json,hybridcore,0x40,0x000005,Core
+GenuineIntel-18-3,V1.00,/NVL/events/novalake_uncore.json,uncore,,,

--- a/scripts/ci/verify_mapfile/mapfile_schema.json
+++ b/scripts/ci/verify_mapfile/mapfile_schema.json
@@ -8,7 +8,7 @@
         "properties" : {
             "Family-model" : {
                 "type": "string",
-                "pattern": "^GenuineIntel-(6|18)-[A-F0-9]{2}(-\\[[A-F0-9]+\\])?$"
+                "pattern": "^GenuineIntel-(6|18)-[A-F0-9]{1,2}(-\\[[A-F0-9]+\\])?$"
             },
             "Version" : {
                 "type": "string",


### PR DESCRIPTION
Drop leading 0 from NVL models `0x01` and `0x03`. Example output below. No other changes expected.

```diff
--- perf/mapfile.csv    2026-07-27 19:56:26.487544422 -0700
+++ pr/mapfile.csv      2026-07-27 19:56:50.243544486 -0700
@@ -25,7 +25,7 @@ GenuineIntel-6-BD,v1.26,lunarlake,core
 GenuineIntel-6-(AA|AC|B5),v1.22,meteorlake,core
 GenuineIntel-6-1[AEF],v4,nehalemep,core
 GenuineIntel-6-2E,v4,nehalemex,core
-GenuineIntel-18-0[13],v1.00,novalake,core
+GenuineIntel-18-[13],v1.00,novalake,core
 GenuineIntel-6-(CC|D5|E5),v1.07,pantherlake,core
 GenuineIntel-6-A7,v1.04,rocketlake,core
 GenuineIntel-6-2A,v19,sandybridge,core
```