### PR TITLE
scripts: Update minor spelling issues

### DIFF
--- a/scripts/create_perf_json.py
+++ b/scripts/create_perf_json.py
@@ -553,7 +553,7 @@ class Model:
         @param shortname: typically 3 letter name like SKL.
         @param longname: the model name like Skylake.
         @param version: the version number associated with the event json.
-        @param models: a set of model indentifier strings like "GenuineIntel-6-2E".
+        @param models: a set of model identifier strings like "GenuineIntel-6-2E".
         @param files: a mapping from a type of file to the file's path.
         """
         self.shortname = shortname
@@ -586,16 +586,16 @@ class Model:
             if len(min(self.models)) - len(prefix) > 1:
                 start_bracket = '('
                 end_bracket = ')'
-                seperator = '|'
+                separator = '|'
             else:
                 start_bracket = '['
                 end_bracket = ']'
-                seperator = ''
+                separator = ''
             ret = prefix + start_bracket
             first = True
             for x in self.models:
                 if not first:
-                    ret += seperator
+                    ret += separator
                 ret += x[len(prefix):]
                 first = False
             ret += end_bracket

--- a/scripts/perf_format_converter.py
+++ b/scripts/perf_format_converter.py
@@ -75,7 +75,7 @@ def main():
     # Get file pointers from args
     arg_input_file, args_tma = get_args()
 
-    # Check that intput/output dirs exists
+    # Check that input/output dirs exists
     ensure_directories()
 
     # Check for input file arg
@@ -89,7 +89,7 @@ def main():
             convert_file(file, args_tma)
 
 def ensure_directories():
-    # Check that intput/output dirs exists
+    """Check that input/output dirs exists"""
     try:
         if not Path(FILE_PATH, INPUT_DIR_PATH).exists():
             Path(FILE_PATH, INPUT_DIR_PATH).mkdir(parents=True, exist_ok=True)
@@ -364,7 +364,7 @@ class PerfFormatConverter:
         un-aliased expressions.
 
         @param metric: metric data as a dictionary
-        @param platform: dictonary with platform info
+        @param platform: dictionary with platform info
         @returns: string containing un-aliased expression
         """
         try:
@@ -376,7 +376,7 @@ class PerfFormatConverter:
                     print("Error: TMA metric without base formula found")
             # Non TMA metric
             else:
-                # Seperate operators with spaces
+                # Separate operators with spaces
                 aliased_formula = fixSpacing(metric["Formula"])
 
                 # Get formula and events for conversion


### PR DESCRIPTION
This commit makes the following changes. No functional changes expected. Closes #100.

```
indentifier ==> identifier
seperator ==> separator
dictonary ==> dictionary
Seperate ==> Separate
intput ==> input
```